### PR TITLE
inputs align to left

### DIFF
--- a/Client/src/pages/SignUp.jsx
+++ b/Client/src/pages/SignUp.jsx
@@ -126,7 +126,7 @@ const SignUp = () => {
               </label>
               <input
                 type="text"
-                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-center"
+                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-left"
                 id="name"
                 placeholder="Enter Name"
                 value={name}
@@ -142,7 +142,7 @@ const SignUp = () => {
               </label>
               <input
                 type="email"
-                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-center"
+                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-leftt"
                 id="email"
                 placeholder="Email address"
                 value={email}
@@ -158,7 +158,7 @@ const SignUp = () => {
               </label>
               <input
                 type="password"
-                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-center"
+                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-left"
                 id="password"
                 placeholder="Password"
                 value={password}

--- a/Client/src/pages/login.jsx
+++ b/Client/src/pages/login.jsx
@@ -125,7 +125,7 @@ const Login = () => {
               </label>
               <input
                 type="email"
-                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-center"
+                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-left"
                 id="email"
                 placeholder="Email address"
                 value={email}
@@ -141,7 +141,7 @@ const Login = () => {
               </label>
               <input
                 type="password"
-                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-center"
+                className="appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline text-left"
                 id="password"
                 placeholder="Password"
                 value={password}


### PR DESCRIPTION
As mentioned in the issue #54  the signup and signin input text align to left is fixed
![Screenshot from 2023-10-08 15-27-01](https://github.com/Saurav-Pant/Blood-Donation-Project/assets/108184152/956e64dc-76cc-468f-9d77-064f97170a72)
I couldn't find the suitable favicon for the website. I will raise the issue when I find a suitable one.
Thankyou.
Closed: #54 