### PR TITLE
Removed heartbeat image in smaller width devices

### DIFF
--- a/src/components/GetBlood.tsx
+++ b/src/components/GetBlood.tsx
@@ -69,7 +69,7 @@ const GetBlood = () => {
             <Image
               src={heartbeat}
               alt=""
-              className=" scale-[0.6] lg:scale-[1.1]"
+              className=" scale-[0.6] lg:scale-[1.1] max-[650px]:hidden"
             />
           </div>
           <div className="grid grid-cols-3">


### PR DESCRIPTION
Resolves issue #144 

Changes made -> Added a new media query in the heartbeat image that hides it after a certain screen width to improve UI

Earlier ->

![image](https://github.com/Saurav-Pant/Blood-Donation-Project/assets/114401238/3fdb5dbf-85b0-4e19-9fe7-fb9f6afa9290)

Resolved ->

![image](https://github.com/Saurav-Pant/Blood-Donation-Project/assets/114401238/25399051-f81e-4567-9e30-95cd7c1aabd3)
