### PR TITLE
added workflow as mentioned in issue #209

### DIFF
--- a/.github/workflows/close-on-merge.yml
+++ b/.github/workflows/close-on-merge.yml
@@ -1,0 +1,30 @@
+name: Close Issues on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Close linked issues
+      if: github.event.pull_request.merged == true
+      run: |
+        ISSUES=$(jq -r '.pull_request.body' "$GITHUB_EVENT_PATH" | grep -Eo '#[0-9]+' | tr -d '#')
+        for ISSUE in $ISSUES
+        do
+          echo "Closing issue #$ISSUE"
+          curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE/comments \
+               -d '{"body":"Closed by PR #${{ github.event.pull_request.number }}"}'
+          curl -X PATCH -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+               -H "Accept: application/vnd.github.v3+json" \
+               https://api.github.com/repos/${{ github.repository }}/issues/$ISSUE \
+               -d '{"state":"closed"}'
+        done


### PR DESCRIPTION
## Related Issue

Fixes #209 

## Description
As the repo maintainers have to manually close an issue after merging a PR linked with that issue, I propose a workflow where the issue linked with a PR which be automatically closed when that PR is merged by the maintainer and efforts will be saved.

## Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________


## Checklist:
- [X] I have performed a self-review of my code
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->

