### PR TITLE
reduced size of Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.github
+.git
+.gitignore
+CODE_OF_CONDUCT.md
+README.md
+contributing.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,6 @@
-FROM node:20-alpine
-
+FROM node:18-alpine
 WORKDIR /app
-
-COPY package*.json ./
-
-RUN npm install
-
-COPY . .
-
-RUN npm run build
-
 EXPOSE  3000
-
-CMD ["npm", "start"]
+COPY . .
+RUN npm install
+CMD npm run dev


### PR DESCRIPTION
## Related Issue
solved issue #233

## Description
The current Dockerfile generates a 2.17 GB image. I have reduced it to 1.32 GB

## Type of PR

- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update
- [ ] Other (specify): _______________

## Screenshots / videos (if applicable)
reduced size of docker image 👇
![dasvfCADxcA](https://github.com/Saurav-Pant/Blood-Donation-Project/assets/140754596/87fa24ef-afd1-4ed5-8be7-163a6db01952)

dockerfile builds successfully, and the website also runs smoothly 👇

https://github.com/Saurav-Pant/Blood-Donation-Project/assets/140754596/03ba9b7c-0bad-4f0c-a64f-7dea11b31de2


## Checklist:
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
<!-- [X] - put a cross/X inside [] to check the box -->
